### PR TITLE
Fixed bug - uninstall last module failures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": ">=5.3.2",
     "nette/nette": ">=2.0.0",
-    "flame/module-installer": "@dev"
+    "flame/module-installer": ">=0.1.2"
   },
 
   "require-dev": {


### PR DESCRIPTION
If I remove last module and run 

``` bash
$ composer update
```

this process fails (http://d.pr/i/vULa) because first remove module-installer package
