### PR TITLE
Makra by se měla předávat na onCompile

### DIFF
--- a/Flame/Modules/DI/ModulesExtension.php
+++ b/Flame/Modules/DI/ModulesExtension.php
@@ -140,7 +140,7 @@ class ModulesExtension extends Nette\DI\CompilerExtension
 					}
 				}
 
-				$latte->addSetup($macro . '(?->getCompiler())', array('@self'));
+				$latte->addSetup('?->onCompile[] = function($engine) { ' . $macro . '($engine->getCompiler()); }', array('@self'));
 			}
 		}
 	}


### PR DESCRIPTION
Stávající implementace nedovoluj překrýt makra implementovaná v Nette. Což je docela problém, když chce někdo překrýt aby inputy a labely přidělávali classy pro bootstrap apod. viz tohle: http://forum.nette.org/cs/17822-lze-prekryt-defaultni-makra-v-nette-2-2

Jo tohle funguje jen v nette 2.2, ale podle composer.json nižší nepodporujete, ne?
