### PR TITLE
Oprava názvu modulu pro NetteRouteListMock

### DIFF
--- a/Flame/Modules/DI/ModulesExtension.php
+++ b/Flame/Modules/DI/ModulesExtension.php
@@ -252,8 +252,8 @@ class ModulesExtension extends Nette\DI\CompilerExtension
 			return new NetteRouteMock($route->getMask(), $route->getDefaults(), $route->getFlags());
 
 		}elseif ($route instanceof Nette\Application\Routers\RouteList) {
-
-			$mock = new NetteRouteListMock($route->getModule());
+			$module = trim($route->getModule(), ':');
+			$mock = new NetteRouteListMock($module);
 
 			foreach($route as $item) {
 				$mock[] = $this->createRouteMock($item);


### PR DESCRIPTION
Sice jsem u #14 psal, že už routelisty jdou v pohodě, ale nějak stejně stávkují. Problém byl s tím, že $route->getModule() vrací i dvojtečku, teď už to je v pohodě.
