### PR TITLE
Added support for routers priorization

### DIFF
--- a/Flame/Modules/DI/ModulesExtension.php
+++ b/Flame/Modules/DI/ModulesExtension.php
@@ -296,14 +296,9 @@ class ModulesExtension extends Nette\DI\CompilerExtension
 		$router = $builder->getDefinition('router');
 
 		// Init collections
-		$routerFactories = [];
+		$routerFactories = array();
 
-		foreach (array_keys($builder->findByTag(self::TAG_ROUTER)) as $serviceName) {
-			$service = $builder->getDefinition($serviceName);
-
-			// Try to get priority from service tag
-			$priority = $service->getTag(self::TAG_ROUTER);
-
+		foreach ($builder->findByTag(self::TAG_ROUTER) as $serviceName => $priority) {
 			// Priority is not defined...
 			if (is_bool($priority)) {
 				// ...use default value


### PR DESCRIPTION
Now if you add number to the tag, this number is used for prioritizing of registered router. Lowe number is lower priority. If no priority is set, then the default is used (100)
