### PR TITLE
Neseřazovat routy

### DIFF
--- a/Flame/Modules/DI/ModulesExtension.php
+++ b/Flame/Modules/DI/ModulesExtension.php
@@ -313,7 +313,6 @@ class ModulesExtension extends Nette\DI\CompilerExtension
 			krsort($routerFactories, SORT_NUMERIC);
 
 			foreach ($routerFactories as $priority => $items) {
-				ksort($items, SORT_STRING);
 				$routerFactories[$priority] = $items;
 			}
 


### PR DESCRIPTION
Podle mě tento ksort by zde být neměl. Podle priority se to seřadí výše, ale pak to ještě seřadí ty routerFactories, což dělá celkem bordel.

Pokud mám na jedné prioritě daný:
profil/<id>-slug
a 
<category>/<id>-slug - ktera je pojmenovaná (definuji ji v Extension - musi mit jmeno.

tak mi to hodi tu pojmenovanou na konec a je pak nad tim profil - tim padem nikdy neni machnuty profil.

Kdyz pojmenuji vice rout a zalezi na poradi, tak mi to udela celkem slusnou paseku asi:)
